### PR TITLE
Fix small papercuts around setup

### DIFF
--- a/lib/phoenix_test/case.ex
+++ b/lib/phoenix_test/case.ex
@@ -90,7 +90,11 @@ defmodule PhoenixTest.Case do
       if trace = context[:trace] do
         BrowserContext.start_tracing(context_id)
 
-        dir = :phoenix_test |> Application.fetch_env!(:playwright) |> Keyword.fetch!(:trace_dir)
+        dir =
+          :phoenix_test
+          |> Application.fetch_env!(:playwright)
+          |> Keyword.get(:trace_dir, "tmp")
+
         File.mkdir_p!(dir)
 
         "Elixir." <> module = to_string(context.module)
@@ -126,7 +130,11 @@ defmodule PhoenixTest.Case do
       end
 
       defp checkout_ecto_repo(repo, async?) do
-        :ok = Ecto.Adapters.SQL.Sandbox.checkout(repo)
+        case Ecto.Adapters.SQL.Sandbox.checkout(repo) do
+          :ok -> :ok
+          {:already, :allowed} -> :ok
+        end
+
         unless async?, do: Ecto.Adapters.SQL.Sandbox.mode(repo, {:shared, self()})
 
         repo


### PR DESCRIPTION
This fixes two small issues I ran into when configuring the Playwright tests for the first time:

- Missing `:trace_dir` option compared to the "Setup" instructions in the docs
- Crash when checking out the repo due to my test case already having done the checkout