### PR TITLE
Fix `:browser` config

### DIFF
--- a/lib/phoenix_test/case.ex
+++ b/lib/phoenix_test/case.ex
@@ -36,8 +36,12 @@ defmodule PhoenixTest.Case do
         opts = Keyword.merge(@playwright_opts, global_browser_config)
         [browser_id: Case.Playwright.launch_browser(opts), trace: trace]
 
-      %{playwright: opts} when is_list(opts) ->
-        opts = Keyword.merge(@playwright_opts, global_browser_config)
+      %{playwright: context_browser_config} when is_list(context_browser_config) ->
+        opts =
+          @playwright_opts
+          |> Keyword.merge(global_browser_config)
+          |> Keyword.merge(context_browser_config)
+
         [browser_id: Case.Playwright.launch_browser(opts), trace: trace]
 
       _ ->

--- a/lib/phoenix_test/case.ex
+++ b/lib/phoenix_test/case.ex
@@ -27,14 +27,17 @@ defmodule PhoenixTest.Case do
   ]
 
   setup_all context do
-    trace = Map.get(context, :trace, Application.fetch_env!(:phoenix_test, :playwright)[:trace])
+    global_config = Application.fetch_env!(:phoenix_test, :playwright)
+    global_browser_config = List.wrap(global_config[:browser])
+    trace = Map.get(context, :trace, global_config[:trace])
 
     case context do
       %{playwright: true} ->
-        [browser_id: Case.Playwright.launch_browser(@playwright_opts), trace: trace]
+        opts = Keyword.merge(@playwright_opts, global_browser_config)
+        [browser_id: Case.Playwright.launch_browser(opts), trace: trace]
 
       %{playwright: opts} when is_list(opts) ->
-        opts = Keyword.merge(@playwright_opts, opts)
+        opts = Keyword.merge(@playwright_opts, global_browser_config)
         [browser_id: Case.Playwright.launch_browser(opts), trace: trace]
 
       _ ->

--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -52,6 +52,22 @@ defmodule PhoenixTest.Playwright do
     timeout_ms: 2000
   ```
 
+  Note that the same options you pass to `:playwright` in your global configuration can also
+  be passed to the `@tag` in your test module. Thus, you might set the global default to
+  `headless: false`, then override it for a single module by setting up your test like this:
+
+  ```elixir
+  defmodule DebuggingFeatureTest do
+    use PhoenixTest.Case, async: true
+
+    # Run this module's tests in a headed browser, with a 1000 millisecond
+    # pause between browser interactions.
+    @moduletag playwright: [headless: false, slowMo: 1_000]
+
+    ...
+  end
+  ```
+
   ## Playwright Traces
   You can enable [trace](https://playwright.dev/docs/trace-viewer-intro) recording in different ways:
   - Environment variable, see [Configuration](#module-configuration)


### PR DESCRIPTION
The `:browser` config was documented as passing arguments to Playwright (in my case, `:headless` was the important one), but the actual config being passed to Playwright appeared to be entirely static. This allows either your global config or a `@tag playwright: some_opts_here` to override that config.