### PR TITLE
Improve test setup and add docs on how to run the tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ Execute PhoenixTest cases in an actual browser via Playwright.
 **Documentation:** [hexdocs.pm](https://hexdocs.pm/phoenix_test_playwright/)
 
 **Example:** [ftes/phoenix_test_playwright_example](https://github.com/ftes/phoenix_test_playwright_example)
+
+## Contributing
+
+To run the tests locally, you'll need to:
+
+1. Check out the repo
+2. Run `mix setup`. This will take care of setting up your dependencies, installing the JavaScript dependencies (including Playwright), and compiling the assets.
+3. Run `mix test` or, for a more thorough check that matches what we test in CI, run `mix check`

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,15 @@ defmodule PhoenixTestPlaywright.MixProject do
       name: "PhoenixTestPlaywright",
       source_url: @source_url,
       docs: docs(),
-      aliases: aliases()
+      aliases: aliases(),
+      preferred_cli_env: [
+        setup: :test,
+        check: :test,
+        "assets.setup": :test,
+        "assets.build": :test,
+        esbuild: :test,
+        "esbuild.install": :test
+      ]
     ]
   end
 
@@ -64,8 +72,18 @@ defmodule PhoenixTestPlaywright.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "assets.setup", "assets.build"],
-      "assets.setup": ["esbuild.install --if-missing"],
-      "assets.build": ["esbuild default"]
+      "assets.setup": [
+        "esbuild.install --if-missing",
+        "cmd npm install --prefix priv/static/assets",
+        "cmd npm exec --prefix priv/static/assets playwright install chromium --with-deps --only-shell"
+      ],
+      "assets.build": ["esbuild default"],
+      check: [
+        "format --check-formatted",
+        "compile --warnings-as-errors",
+        "assets.build",
+        "test --warnings-as-errors --max-cases 1"
+      ]
     ]
   end
 end


### PR DESCRIPTION
I was having trouble getting the tests to run locally because the `esbuild` package is only available in `MIX_ENV=test`. To that end, I made the `mix setup` task (and its subtasks) run in `MIX_ENV=test` by default, and added a new `mix check` action that mirrors how CI tests a PR.