### PR TITLE
Improve error messages for duplicate elements

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -469,10 +469,11 @@ defmodule PhoenixTest.Playwright do
 
         flunk("#{error_header}\n#{more_info}")
 
-      {:error,
-       %{error: %{error: %{name: "Error", message: "Error: strict mode violation" <> _}}} = error} ->
+      {:error, %{error: %{error: %{message: "Error: strict mode violation: " <> _ = message}}}} ->
+        short_message = String.replace(message, "Error: strict mode violation: ", "")
+
         flunk(
-          "Found more than one element matching selector #{debug_selector}:\n#{inspect(error)}"
+          "Found more than one element matching selector #{debug_selector}:\n#{short_message}"
         )
 
       {:error,


### PR DESCRIPTION
Before:

```
  1) test does not start the recording when clicking New Meeting > Upload meeting audio (JumpWeb.App.MeetingLiveBrowserTest)
     lib/jump_web/live/meeting_live_test.exs:1079
     Found more than one element matching selector internal:role=link[name="Upload meeting audio"i]:
     %{error: %{error: %{message: "Error: strict mode violation: getByRole('link', { name: 'Upload meeting audio' }) resolved to 2 elements:\n    1) <a href=\"/meetings/new\" data-phx-link=\"redirect\" data-phx-link-state=\"push\" data-phx-id=\"m7-meeting_status\" class=\"flex flex-row items-center gap-2 px-2 py-1.5 hover:bg-dropdown-active rounded-md pc-dropdown__menu-item \">…</a> aka getByRole('link', { name: 'Upload meeting audio Use for' })\n    2) <a target=\"_self\" href=\"/meetings/new\" data-phx-link=\"redirect\" data-phx-link-state=\"push\" class=\"flex items-center py-2 px-4\" data-phx-id=\"m59-phx-GBqZ6txJ8RNflReB\">…</a> aka getByRole('link', { name: 'Upload meeting audio In-' })\n", name: "Error", stack: "Error: Error: strict mode violation: getByRole('link', { name: 'Upload meeting audio' }) resolved to 2 elements:\n    1) <a href=\"/meetings/new\" data-phx-link=\"redirect\" data-phx-link-state=\"push\" data-phx-id=\"m7-meeting_status\" class=\"flex flex-row items-center gap-2 px-2 py-1.5 hover:bg-dropdown-active rounded-md pc-dropdown__menu-item \">…</a> aka getByRole('link', { name: 'Upload meeting audio Use for' })\n    2) <a target=\"_self\" href=\"/meetings/new\" data-phx-link=\"redirect\" data-phx-link-state=\"push\" class=\"flex items-center py-2 px-4\" data-phx-id=\"m59-phx-GBqZ6txJ8RNflReB\">…</a> aka getByRole('link', { name: 'Upload meeting audio In-' })\n\n    at CRExecutionContext.evaluateWithArguments (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/chromium/crExecutionContext.js:79:33)\n    at async LongStandingScope._race (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/utils/manualPromise.js:96:14)\n    at async evaluateExpression (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/javascript.js:229:12)\n    at async /Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/frames.js:965:22\n    at async Frame.retryWithProgressAndTimeouts (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/frames.js:935:24)\n    at async /Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/frames.js:1023:29\n    at async ProgressController.run (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/progress.js:79:22)\n    at async FrameDispatcher.click (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/dispatchers/frameDispatcher.js:158:12)\n    at async LongStandingScope._race (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/utils/manualPromise.js:96:14)\n    at async FrameDispatcher._handleCommand (/Users/tyler/jump/api/assets/node_modules/playwright-core/lib/server/dispatchers/dispatcher.js:96:14)"}}, id: 11, log: ["  - waiting for getByRole('link', { name: 'Upload meeting audio' })"]}
     code: |> click_link("Upload meeting audio")
     stacktrace:
       (phoenix_test_playwright 0.2.0) lib/phoenix_test/playwright.ex:355: PhoenixTest.Playwright.click_link/4
       lib/jump_web/live/meeting_live_test.exs:1086: (test)
```

After:

```
  1) test does not start the recording when clicking New Meeting > Upload meeting audio (JumpWeb.App.MeetingLiveBrowserTest)
     lib/jump_web/live/meeting_live_test.exs:1079
     Found more than one element matching selector internal:role=link[name="Upload meeting audio"i]:
     getByRole('link', { name: 'Upload meeting audio' }) resolved to 2 elements:
         1) <a href="/meetings/new" data-phx-link="redirect" data-phx-link-state="push" data-phx-id="m7-meeting_status" class="flex flex-row items-center gap-2 px-2 py-1.5 hover:bg-dropdown-active rounded-md pc-dropdown__menu-item ">…</a> aka getByRole('link', { name: 'Upload meeting audio Use for' })
         2) <a target="_self" href="/meetings/new" data-phx-link="redirect" data-phx-link-state="push" class="flex items-center py-2 px-4" data-phx-id="m54-phx-GBqaEZ3NwFSjRQQE">…</a> aka getByRole('link', { name: 'Upload meeting audio In-' })

     code: |> click_link("Upload meeting audio")
     stacktrace:
       (phoenix_test_playwright 0.2.0) lib/phoenix_test/playwright.ex:355: PhoenixTest.Playwright.click_link/4
       lib/jump_web/live/meeting_live_test.exs:1086: (test)
```