### PR TITLE
Match on incomplete button text by default

### DIFF
--- a/lib/phoenix_test/playwright/selector.ex
+++ b/lib/phoenix_test/playwright/selector.ex
@@ -42,7 +42,23 @@ defmodule PhoenixTest.Playwright.Selector do
   def at(at), do: "nth=#{at}"
 
   def link(text, opts), do: role("link", text, opts)
-  def button(text, opts), do: role("button", text, opts)
+
+  def button(text, opts) do
+    if opts[:exact] do
+      role("button", text, opts)
+    else
+      "css=" <>
+        Enum.join(
+          [
+            "button:has-text(\"#{text}\")",
+            "input[type=button]:has-text(\"#{text}\")",
+            "[role=button]:has-text(\"#{text}\")"
+          ],
+          ","
+        )
+    end
+  end
+
   def menuitem(text, opts), do: role("menuitem", text, opts)
   def role(role, text, opts), do: "internal:role=#{role}[name=\"#{text}\"#{exact_suffix(opts)}]"
 

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -59,6 +59,50 @@ defmodule PhoenixTest.PlaywrightTest do
         |> click_button("Show tab")
       end
     end
+
+    test "inexact match matches on substring text", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("Also shows the tab")
+      |> assert_has("#tab", text: "Tab title")
+
+      conn
+      |> visit("/live/index")
+      |> click_button(".substring-match", "shows the tab")
+      |> assert_has("#tab", text: "Tab title")
+
+      conn
+      |> visit("/live/index")
+      |> click_button("Input that displays the tab")
+      |> assert_has("#tab", text: "Tab title")
+
+      conn
+      |> visit("/live/index")
+      |> click_button(".substring-match", "*also* shows that same tab")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "exact match does not match partial text", %{conn: conn} do
+      assert_raise AssertionError, ~r/Could not find/, fn ->
+        conn
+        |> visit("/live/index")
+        |> PhoenixTest.Playwright.click_button(nil, "Also shows the tab", exact: true)
+      end
+
+      assert_raise AssertionError, ~r/Could not find/, fn ->
+        conn
+        |> visit("/live/index")
+        |> PhoenixTest.Playwright.click_button(".substring-match", "Also shows the tab",
+          exact: true
+        )
+        |> assert_has("#tab", text: "Tab title")
+      end
+
+      conn
+      |> visit("/live/index")
+      |> PhoenixTest.Playwright.click_button(nil, "Show tab", exact: true)
+      |> assert_has("#tab", text: "Tab title")
+    end
   end
 
   describe "within/3" do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -23,6 +23,9 @@ defmodule PhoenixTest.IndexLive do
     <button phx-click="change-page-title">Change page title</button>
 
     <button phx-click="show-tab">Show tab</button>
+    <button phx-click="show-tab" class="substring-match">Also shows the tab (with some additional text {Enum.random(1..100)})</button>
+    <input type="button" value="Input that displays the tab (with additional text)" class="substring-match" phx-click="show-tab" />
+    <div role="button" phx-click="show-tab" class="substring-match">*Also* shows that same tab (with additional text)</div>
 
     <div :if={@show_tab} id="tab">
       <h2>Tab title</h2>


### PR DESCRIPTION
This makes the `click_button` action behave like that of `PhoenixTest`, by matching on incomplete button text.

Given the HTML:

```html
<button>Do the thing now</button>
```

...or an equivalent `<input type="button">` or `role="button"` element, `PhoenixTest.click_button/{2,3}` supports passing any substring of the button text ("Do the thing", "the thing now", etc.) to match, so this change makes `PhoenixTest.Playwright.click_button` match that behavior.

I'm not 100% sure this doesn't have other (potentially undesirable?) effects on other matchers, but the test suite passes... 👀