### PR TITLE
Typo in `assert_download` helper in doc

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -220,10 +220,10 @@ defmodule PhoenixTest.Playwright do
     assert_receive({:playwright, %{method: :download} = download_msg}, 2000)
     artifact_guid = download_msg.params.artifact.guid
     assert_receive({:playwright, %{method: :__create__, params: %{guid: ^artifact_guid}} = artifact_msg}, 2000)
-    download_path = artifact_msg.params.initializer.absolutePath
+    download_path = artifact_msg.params.initializer.absolute_path
     wait_for_file(download_path)
 
-    assert download_msg.params.suggestedFilename =~ name
+    assert download_msg.params.suggested_filename =~ name
     assert File.read!(download_path) =~ content
 
     session


### PR DESCRIPTION
Got the following errors when running a test with `assert_download`:

```bash
** (KeyError) key :absolutePath not found in: %{
       absolute_path: "/var/folders/g_/5n3kmxt55lq8chxzj8bwxfh80000gn/T/playwright-artifacts-rLpjLH/872f4493-0a7b-44b9-9956-ee59bf2578f1"
     }. Did you mean:

           * :absolute_path
```

```bash
** (KeyError) key :suggestedFilename not found in: %{
       url: "blob:http://localhost:4002/50ea1a37-85e5-4c8c-8782-678d88e5a97f",
       artifact: %{guid: "artifact@8a880f882553ae1f344fa48e3dc6f2cb"},
       suggested_filename: "my_file.txt"
     }. Did you mean:

           * :suggested_filename
```