### PR TITLE
Set a generous minimum GenServer timeout

### DIFF
--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -22,7 +22,7 @@ defmodule PhoenixTest.Playwright.Connection do
   require Logger
 
   @timeout_grace_factor 1.5
-  @min_genserver_timeout :timer.seconds(1)
+  @min_genserver_timeout to_timeout(second: 1)
 
   defstruct [
     :port,

--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -22,6 +22,7 @@ defmodule PhoenixTest.Playwright.Connection do
   require Logger
 
   @timeout_grace_factor 1.5
+  @min_genserver_timeout :timer.seconds(1)
 
   defstruct [
     :port,
@@ -76,7 +77,7 @@ defmodule PhoenixTest.Playwright.Connection do
   def post(msg, timeout \\ nil) do
     default = %{params: %{}, metadata: %{}}
     msg = msg |> Enum.into(default) |> update_in(~w(params timeout)a, &(&1 || timeout || Config.global(:timeout)))
-    call_timeout = round(msg.params.timeout * @timeout_grace_factor)
+    call_timeout = max(@min_genserver_timeout, round(msg.params.timeout * @timeout_grace_factor))
     GenServer.call(@name, {:post, msg}, call_timeout)
   end
 


### PR DESCRIPTION
Since the 0.5.0 release, we've seen in an issue in CI where our tests become unreliable due to GenServer timeouts.

For instance, if I do:

```elixir
refute_has(session, "div", text: "Should not exist", timeout: 100)
```

...it will often fail in our GitHub Actions CI, I assume because the CI machine is so dog slow that it can't shuttle a message between Playwright and PhoenixTest.Playwright within 150 milliseconds. Here's what the stacktrace looks like:

```
 ** (exit) exited in: GenServer.call(PhoenixTest.Playwright.Connection, {:post, %{metadata: %{}, params: %{timeout: 100, selector: "css=div >> visible=true >> internal:text=\"Should not exist\"i"}, method: :wait_for_selector, guid: "frame@55ce48fd95bf3348e115d23465662fcc"}}, 150)
     ** (EXIT) time out
 code: |> refute_has("div", text: "Should not exist", timeout: 100)
 stacktrace:
   (elixir 1.18.2) lib/gen_server.ex:1128: GenServer.call/3
   (phoenix_test_playwright 0.5.0) lib/phoenix_test/playwright/frame.ex:78: PhoenixTest.Playwright.Frame.wait_for_selector/2
   (phoenix_test_playwright 0.5.0) lib/phoenix_test/playwright.ex:551: PhoenixTest.Playwright.found?/3
   (phoenix_test_playwright 0.5.0) lib/phoenix_test/playwright.ex:515: PhoenixTest.Playwright.refute_has/3
   lib/jump_web/live/meeting_live_browser_test.exs:71: (test)
```

You can see there that the `GenServer.call/3` timeout was 150 (i.e., 1.5 times the 100 ms I specified I'd be willing to wait to confirm the text wasn't on the page).

My proposed fix is to set a minimum GenServer timeout of a second. That will ensure that you can specify a low timeout for refutations without risking a GenServer crash.