### PR TITLE
Add browser_launch_timeout configuration option and improve launch timeout error message

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -92,6 +92,7 @@ defmodule PhoenixTest.Playwright do
       js_logger: false,
       screenshot: System.get_env("PW_SCREENSHOT", "false") in ~w(t true),
       trace: System.get_env("PW_TRACE", "false") in ~w(t true),
+      browser_launch_timeout: 10_000,
     ]
   ```
 

--- a/lib/phoenix_test/playwright/config.ex
+++ b/lib/phoenix_test/playwright/config.ex
@@ -35,6 +35,10 @@ schema =
       default: "screenshots",
       type: :string
     ],
+    browser_launch_timeout: [
+      default: to_timeout(second: 4),
+      type: :non_neg_integer
+    ],
     timeout: [
       default: to_timeout(second: 2),
       type: :non_neg_integer

--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -22,7 +22,7 @@ defmodule PhoenixTest.Playwright.Connection do
   require Logger
 
   @timeout_grace_factor 1.5
-  @min_genserver_timeout :timer.seconds(1)
+  @min_genserver_timeout to_timeout(second: 1)
 
   defstruct [
     :port,

--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -22,6 +22,7 @@ defmodule PhoenixTest.Playwright.Connection do
   require Logger
 
   @timeout_grace_factor 1.5
+  @min_genserver_timeout :timer.seconds(1)
 
   defstruct [
     :port,
@@ -76,7 +77,7 @@ defmodule PhoenixTest.Playwright.Connection do
   def post(msg, timeout \\ nil) do
     default = %{params: %{}, metadata: %{}}
     msg = msg |> Enum.into(default) |> update_in(~w(params timeout)a, &(&1 || timeout || Config.global(:timeout)))
-    call_timeout = round(msg.params.timeout * @timeout_grace_factor)
+    call_timeout = max(@min_genserver_timeout, round(msg.params.timeout * @timeout_grace_factor))
     GenServer.call(@name, {:post, msg}, call_timeout)
   end
 

--- a/test/phoenix_test/playwright/connection_test.exs
+++ b/test/phoenix_test/playwright/connection_test.exs
@@ -1,0 +1,28 @@
+defmodule PhoenixTest.Playwright.ConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixTest.Playwright.Connection
+
+  setup_all do
+    Connection.ensure_started()
+  end
+
+  test "launch_browser/2 produces a reasonable error on timeout" do
+    for opts <- [
+          %{browser_launch_timeout: -1_000},
+          # :browser_launch_timeout overrides :timeout for this particular use case
+          %{browser_launch_timeout: -1_000, timeout: 10_000},
+          # :timeout is used as fallback if :browser_launch_timeout is not set
+          %{timeout: -1_000}
+        ] do
+      try do
+        Connection.launch_browser(:chromium, opts)
+        flunk("Launch browser should have raised a timeout error")
+      rescue
+        error in RuntimeError ->
+          assert error.message =~ "Timed out while launching the Playwright browser, Chromium."
+          assert error.message =~ "You may need to increase the :browser_launch_timeout"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This improves the debuggability of the browser launch timing out, an issue we've seen quite a bit in CI at Jump.

I've also added an explicit option for controlling the timeout on the launch of the browser. Using the global `:timeout` option for the browser launch is painful because the browser launch is generally the slowest part of our test suite, and we'd like tighter default timeouts for things like refuting the existence of an element.

Note that the test here depends on changes from #19, which impacts the minimum GenServer timeout on these calls.

## Error message before

```
1) test launch_browser produces a reasonable error on timeout (PhoenixTest.Playwright.ConnectionTest)
test/phoenix_test/playwright/connection_test.exs:10
** (KeyError) key :result not found in: %{
error: %{
error: %{
message: "Timeout 1ms exceeded.",
name: "TimeoutError",
stack: "TimeoutError: Timeout 1ms exceeded.\n at ProgressController.run (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/progress.js:75:26)\n at Chromium.launch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/browserType.js:79:38)\n at BrowserTypeDispatcher.launch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/browserTypeDispatcher.js:35:40)\n at BrowserTypeDispatcher._handleCommand (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/dispatcher.js:94:40)\n at DispatcherConnection.dispatch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/dispatcher.js:361:39)"
}
},
id: 1,
log: [],
method: nil
}
code: Connection.launch_browser(:chromium, timeout: 1)
stacktrace:
(phoenix_test_playwright 0.5.0) lib/phoenix_test/playwright/connection.ex:62: PhoenixTest.Playwright.Connection.launch_browser/2
test/phoenix_test/playwright/connection_test.exs:11: (test)
```

## Error message after

```
1) test launch_browser produces a reasonable error on timeout (PhoenixTest.Playwright.ConnectionTest)
test/phoenix_test/playwright/connection_test.exs:10
** (RuntimeError) Timed out while launching the Playwright browser, Chromium. Timeout 1ms exceeded.

You may need to increase the :browser_launch_timeout option in config/test.exs:

config :phoenix_test,
playwright: [
browser_launch_timeout: 10_000,
# other Playwright options...
],
# other phoenix_test options...

Playwright backtrace:

TimeoutError: Timeout 1ms exceeded.
at ProgressController.run (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/progress.js:75:26)
at Chromium.launch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/browserType.js:79:38)
at BrowserTypeDispatcher.launch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/browserTypeDispatcher.js:35:40)
at BrowserTypeDispatcher._handleCommand (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/dispatcher.js:94:40)
at DispatcherConnection.dispatch (/Users/tyler/Documents/repos/phoenix_test_playwright/priv/static/assets/node_modules/playwright-core/lib/server/dispatchers/dispatcher.js:361:39)

code: Connection.launch_browser(:chromium, browser_launch_timeout: 1)
stacktrace:
(phoenix_test_playwright 0.5.0) lib/phoenix_test/playwright/connection.ex:73: PhoenixTest.Playwright.Connection.launch_browser/2
test/phoenix_test/playwright/connection_test.exs:11: (test)
```

Resolves #20
