### PR TITLE
Handle a case in which there's not a string but an atom passed to underscore

### DIFF
--- a/lib/phoenix_test/playwright/serialization.ex
+++ b/lib/phoenix_test/playwright/serialization.ex
@@ -4,7 +4,9 @@ defmodule PhoenixTest.Playwright.Serialization do
   require Logger
 
   def camelize(input), do: input |> to_string() |> Phoenix.Naming.camelize(:lower)
-  def underscore(string), do: string |> Phoenix.Naming.underscore() |> String.to_atom()
+
+  def underscore(string) when is_binary(string), do: string |> Phoenix.Naming.underscore() |> String.to_atom()
+  def underscore(atom) when is_atom(atom), do: atom
 
   def deep_key_camelize(input), do: deep_key_transform(input, &camelize/1)
   def deep_key_underscore(input), do: deep_key_transform(input, &underscore/1)


### PR DESCRIPTION
While adapting https://ftes.de/articles/2024-12-02-axe-a11y-audit-with-playwright-for-elixir?utm_source=elixir-merge the deserialization failed with a bad match. Adding the atom variant fixes this problem but might not be the best way to handle this because the serializer returns mixed maps.

```
 test register (WelcomeTest)
     test/attika_web/welcome_test.exs:4
     ** (MatchError) no match of right hand side value: "data"
     stacktrace:
       (elixir 1.18.3) lib/macro.ex:2197: Macro.underscore/1
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:7: PhoenixTest.Playwright.Serialization.underscore/1
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:66: anonymous fn/2 in PhoenixTest.Playwright.Serialization.deep_key_transform/2
       (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
       (elixir 1.18.3) lib/map.ex:251: Map.new_from_map/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:63: anonymous fn/2 in PhoenixTest.Playwright.Serialization.deep_key_transform/2
       (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
       (elixir 1.18.3) lib/map.ex:251: Map.new_from_map/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:35: anonymous fn/1 in PhoenixTest.Playwright.Serialization.deserialize_arg/1
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/map.ex:262: Map.new_from_enum/2
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:35: PhoenixTest.Playwright.Serialization.deserialize_arg/1
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (phoenix_test_playwright 0.6.1) lib/phoenix_test/playwright/serialization.ex:35: anonymous fn/1 in PhoenixTest.Playwright.Serialization.deserialize_arg/1
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
       (elixir 1.18.3) lib/map.ex:262: Map.new_from_enum/2
```

The result from A11yAudit (adapted from https://ftes.de/articles/2024-12-02-axe-a11y-audit-with-playwright-for-elixir)

```elixir
defmodule A11y do
  @moduledoc """
  Bridge between PhoenixTest and A11yAudit
  Based upon https://ftes.de/articles/2024-12-02-axe-a11y-audit-with-playwright-for-elixir
  """
  def assert_accessible(session) do
    run_audit =
      fn ->
        PhoenixTest.Playwright.Frame.evaluate(session.frame_id, A11yAudit.JS.axe_core())
        PhoenixTest.Playwright.Frame.evaluate(session.frame_id, "axe.run()")
      end

    results = extract(run_audit.())

    A11yAudit.Assertions.assert_no_violations(results)
  end

  defp extract(%{violations: violations} = results) do
    violations =
      Enum.map(violations, fn v ->
        from_map(v)
      end)

    %{results | violations: violations}
  end

  defp from_map(v) do
    %A11yAudit.Results.Violation{
      id: v.id,
      description: v.description,
      help: v.help,
      help_url: v.help_url,
      impact: v.impact |> String.to_atom(),
      nodes: v.nodes
    }
  end
end

```

returns nested maps, with string and atom-keys which are processed in 
PhoenixTest.Playwright.Serialization#deserialize_arg (line 36)

```elixir
# [...]
%{
  "all" => [
    %{
      data: nil,
      id: "aria-allowed-attr",
      message: "ARIA attributes are used correctly for the defined role",
      impact: "critical",
      related_nodes: []
    }
  ],
  "any" => [],
  "html" => "<div id=\"flash-group\" aria-live=\"polite\" data-phx-id=\"m1-phx-GDbJDF52wqCVJgBD\">",
  "impact" => nil,
  "none" => [
    %{
      data: nil,
      id: "aria-unsupported-attr",
      message: "ARIA attribute is supported",
      impact: "critical",
      related_nodes: []
    }
  ],
  "target" => ["#flash-group"]
}
# [...]
```


