### PR TITLE
Custom browser dialog handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- `PhoenixTest.Playwright.with_dialog/3` to accept or dismiss browser dialogs
-
-### Removed
-- `PhoenixTest.Playwright.Connection.received/` internal function - consider using `PhoenixTest.Playwright.EventRecorder` instead
+- Dialog handling
+  - Config option `accept_dialogs` (default: `true`)
+  - `PhoenixTest.Playwright.with_dialog/3` for conditional handling
 
 ## [0.6.3] 2025-05-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- `PhoenixTest.Playwright.with_dialog/3` to accept or dismiss browser dialogs, based on `with_event_listener`
-- `PhoenixTest.Playwright.with_event_listener/4` to handle arbitrary playwright events via background process
+- `PhoenixTest.Playwright.with_dialog/3` to accept or dismiss browser dialogs
+
+### Removed
+- `PhoenixTest.Playwright.Connection.received/` internal function - consider using `PhoenixTest.Playwright.EventRecorder` instead
 
 ## [0.6.3] 2025-05-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Accept browser dialogs automatically (`alert()`, `confirm()`, `prompt()`)
+- `PhoenixTest.Playwright.with_dialog/3` to accept or dismiss browser dialogs, based on `with_event_listener`
+- `PhoenixTest.Playwright.with_event_listener/4` to handle arbitrary playwright events via background process
 
 ## [0.6.3] 2025-05-05
 ### Added

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -35,7 +35,9 @@ defmodule PhoenixTest.Playwright.Case do
           screenshot: 2,
           screenshot: 3,
           type: 3,
-          type: 4
+          type: 4,
+          with_dialog: 3,
+          with_event_listener: 4
         ]
 
       import PhoenixTest.Playwright.Case
@@ -82,7 +84,6 @@ defmodule PhoenixTest.Playwright.Case do
       }
 
       browser_context_id = Browser.new_context(context.browser_id, browser_context_opts)
-      subscribe(browser_context_id)
 
       page_id = BrowserContext.new_page(browser_context_id)
       Page.update_subscription(page_id, event: :console, enabled: true)

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -36,8 +36,7 @@ defmodule PhoenixTest.Playwright.Case do
           screenshot: 3,
           type: 3,
           type: 4,
-          with_dialog: 3,
-          with_event_listener: 4
+          with_dialog: 3
         ]
 
       import PhoenixTest.Playwright.Case

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -94,7 +94,12 @@ defmodule PhoenixTest.Playwright.Case do
       if config[:trace], do: trace(browser_context_id, config, context)
       if config[:screenshot], do: screenshot(page_id, config, context)
 
-      PhoenixTest.Playwright.build(browser_context_id, page_id, frame_id)
+      PhoenixTest.Playwright.build(%{
+        context_id: browser_context_id,
+        page_id: page_id,
+        frame_id: frame_id,
+        config: config
+      })
     end
 
     defp trace(browser_context_id, config, context) do

--- a/lib/phoenix_test/playwright/config.ex
+++ b/lib/phoenix_test/playwright/config.ex
@@ -55,11 +55,16 @@ schema =
     trace_dir: [
       default: "traces",
       type: :string
+    ],
+    accept_dialogs: [
+      default: true,
+      type: :boolean,
+      doc: "Accept browser dialogs (`alert()`, `confirm()`, `prompt()`"
     ]
   )
 
 setup_all_keys = ~w(browser browser_launch_timeout headless slow_mo)a
-setup_keys = ~w(screenshot trace)a
+setup_keys = ~w(accept_dialogs screenshot trace)a
 
 defmodule PhoenixTest.Playwright.Config do
   @moduledoc """

--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -194,14 +194,6 @@ defmodule PhoenixTest.Playwright.Connection do
 
   defp log_console(state, _), do: state
 
-  defp accept_dialog(state, %{method: :__create__, params: %{type: "Dialog", guid: guid}}) do
-    msg = %{guid: guid, method: :accept, params: %{}, metadata: %{}}
-    PlaywrightPort.post(state.port, msg)
-    state
-  end
-
-  defp accept_dialog(state, _), do: state
-
   defp handle_started(state, %{method: :__create__, params: %{type: "Playwright"}}) do
     for from <- state.awaiting_started, do: GenServer.reply(from, :ok)
     %{state | status: :started, awaiting_started: :none}

--- a/lib/phoenix_test/playwright/dialog.ex
+++ b/lib/phoenix_test/playwright/dialog.ex
@@ -1,0 +1,31 @@
+defmodule PhoenixTest.Playwright.Dialog do
+  @moduledoc """
+  Interact with a Playwright `Dialog`.
+
+  There is no official documentation, since this is considered Playwright internal.
+
+  References:
+  - https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/client/dialog.ts
+  """
+
+  import PhoenixTest.Playwright.Connection, only: [post: 1]
+
+  def accept(dialog_id, opts \\ []) do
+    [guid: dialog_id, method: :accept, params: Map.new(opts)]
+    |> post()
+    |> unwrap_response(& &1)
+  end
+
+  def dismiss(dialog_id, opts \\ []) do
+    [guid: dialog_id, method: :dismiss, params: Map.new(opts)]
+    |> post()
+    |> unwrap_response(& &1)
+  end
+
+  defp unwrap_response(response, fun) do
+    case response do
+      %{error: _} = error -> {:error, error}
+      _ -> {:ok, fun.(response)}
+    end
+  end
+end

--- a/lib/phoenix_test/playwright/event_listener.ex
+++ b/lib/phoenix_test/playwright/event_listener.ex
@@ -1,6 +1,6 @@
 defmodule PhoenixTest.Playwright.EventListener do
   @moduledoc """
-  Sets up a background event listener for the session.
+  Background playwright event listener.
 
   This function starts a background process that will automatically handle events
   according to the provided callback function.

--- a/lib/phoenix_test/playwright/event_listener.ex
+++ b/lib/phoenix_test/playwright/event_listener.ex
@@ -4,20 +4,51 @@ defmodule PhoenixTest.Playwright.EventListener do
 
   This function starts a background process that will automatically handle events
   according to the provided callback function.
+
+  ## Optional callback stack
+  The current callback is the top most on the callback stack.
+  A new callback can be set via `push_callback/2`, and the previous
+  callback can be reverted to via `pop_callback/1`.
   """
   use GenServer
+
+  defstruct [:filter, :callbacks]
+
+  # Public API
+
+  def push_callback(name, callback) when is_function(callback, 1) do
+    GenServer.cast(name, {:push_callback, callback})
+  end
+
+  def pop_callback(name) do
+    GenServer.cast(name, :pop_callback)
+  end
+
+  # Internal
 
   def start_link(%{guid: _, filter: _, callback: _} = args, opts \\ []) do
     GenServer.start_link(__MODULE__, args, opts)
   end
 
+  @impl GenServer
   def init(%{guid: guid, filter: filter, callback: callback}) when is_function(callback, 1) do
     PhoenixTest.Playwright.Connection.subscribe(self(), guid)
-    {:ok, %{filter: filter, callback: callback}}
+    {:ok, %__MODULE__{filter: filter, callbacks: [callback]}}
   end
 
-  def handle_info({:playwright, event}, state) do
-    if state.filter.(event), do: state.callback.(event)
+  @impl GenServer
+  def handle_info({:playwright, event}, %__MODULE__{} = state) do
+    callback = List.first(state.callbacks)
+    if state.filter.(event) and callback, do: callback.(event)
     {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:push_callback, callback}, %__MODULE__{callbacks: callbacks} = state) do
+    {:noreply, %{state | callbacks: [callback | callbacks]}}
+  end
+
+  def handle_cast(:pop_callback, %__MODULE__{callbacks: [_ | callbacks]} = state) do
+    {:noreply, %{state | callbacks: callbacks}}
   end
 end

--- a/lib/phoenix_test/playwright/event_listener.ex
+++ b/lib/phoenix_test/playwright/event_listener.ex
@@ -1,0 +1,23 @@
+defmodule PhoenixTest.Playwright.EventListener do
+  @moduledoc """
+  Sets up a background event listener for the session.
+
+  This function starts a background process that will automatically handle events
+  according to the provided callback function.
+  """
+  use GenServer
+
+  def start_link(%{guid: _, filter: _, callback: _} = args, opts \\ []) do
+    GenServer.start_link(__MODULE__, args, opts)
+  end
+
+  def init(%{guid: guid, filter: filter, callback: callback}) when is_function(callback, 1) do
+    PhoenixTest.Playwright.Connection.subscribe(self(), guid)
+    {:ok, %{filter: filter, callback: callback}}
+  end
+
+  def handle_info({:playwright, event}, state) do
+    if state.filter.(event), do: state.callback.(event)
+    {:noreply, state}
+  end
+end

--- a/lib/phoenix_test/playwright/event_recorder.ex
+++ b/lib/phoenix_test/playwright/event_recorder.ex
@@ -1,0 +1,40 @@
+defmodule PhoenixTest.Playwright.EventRecorder do
+  @moduledoc """
+  Background playwright event recorder.
+
+  Recorded events can be retrieved in LIFO order (last in first out).
+  """
+  use GenServer
+
+  # Public API
+
+  def events(name) do
+    GenServer.call(name, :events)
+  end
+
+  # Internal
+
+  def start_link(%{guid: _, filter: _} = args, opts \\ []) do
+    GenServer.start_link(__MODULE__, args, opts)
+  end
+
+  @impl GenServer
+  def init(%{guid: guid, filter: filter}) do
+    PhoenixTest.Playwright.Connection.subscribe(self(), guid)
+    {:ok, %{filter: filter, events: []}}
+  end
+
+  @impl GenServer
+  def handle_info({:playwright, event}, state) do
+    if state.filter.(event) do
+      {:noreply, Map.update!(state, :events, &[event | &1])}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:events, _from, state) do
+    {:reply, state.events, state}
+  end
+end

--- a/lib/phoenix_test/playwright/frame.ex
+++ b/lib/phoenix_test/playwright/frame.ex
@@ -139,7 +139,7 @@ defmodule PhoenixTest.Playwright.Frame do
   end
 
   def click(frame_id, selector, opts \\ []) do
-    params = %{selector: selector, wait_until: :load, strict: true}
+    params = %{selector: selector, strict: true}
     params = Enum.into(opts, params)
 
     [guid: frame_id, method: :click, params: params]

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -3,7 +3,6 @@ defmodule PhoenixTest.PlaywrightTest do
 
   alias ExUnit.AssertionError
   alias PhoenixTest.Playwright
-  alias PhoenixTest.Playwright.Frame
 
   describe "visit/2" do
     test "navigates to given LiveView page", %{conn: conn} do
@@ -170,28 +169,6 @@ defmodule PhoenixTest.PlaywrightTest do
           |> assert_path("/live/page_2")
         end
       )
-    end
-  end
-
-  describe "with_event_listener/3" do
-    test "forwards console log within inner function, but not before or after", %{conn: conn} do
-      test_process = self()
-
-      conn
-      |> visit("/live/index")
-      |> tap(&Frame.evaluate(&1.frame_id, "console.log('before')"))
-      |> with_event_listener(
-        &match?(%{method: :console}, &1),
-        &send(test_process, {:test_console, &1.params.text}),
-        fn conn ->
-          tap(conn, &Frame.evaluate(&1.frame_id, "console.log('within')"))
-        end
-      )
-      |> tap(&Frame.evaluate(&1.frame_id, "console.log('after')"))
-
-      refute_received({:test_console, "before"})
-      assert_received({:test_console, "within"})
-      refute_received({:test_console, "after"})
     end
   end
 

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -157,8 +157,25 @@ defmodule PhoenixTest.PlaywrightTest do
     end
   end
 
-  describe "with_dialog/3" do
-    test "accepts dialog", %{conn: conn} do
+  describe "browser dialog handling: accept_dialogs config and with_dialog/3" do
+    test "accepts dialog by default", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Confirm to navigate")
+      |> assert_path("/live/page_2")
+    end
+
+    @tag accept_dialogs: false
+    test "override config via tag: dismisses dialog and fails click_link", %{conn: conn} do
+      assert_raise AssertionError, fn ->
+        conn
+        |> visit("/live/index")
+        |> click_link("Confirm to navigate")
+      end
+    end
+
+    @tag accept_dialogs: false
+    test "with_dialog/3 accepts dialog conditionally", %{conn: conn} do
       conn
       |> visit("/live/index")
       |> with_dialog(


### PR DESCRIPTION
Accept dialogs by default.
Add a config option `accept_dialogs` to disable auto-accept globally or for individual tests.
Add `Playwright.with_dialog/3` to conditionally handle dialogs and accept/dismiss them based on the message.

Closes #28

## `accept_dialogs` config
Default: `true` to mimic how vanilla `PhoenixTest` handles `data-confirm` dialogs (implicitly accept).

Override globally in `test.exs` or per test via via ExUnit `@tag accept_dialogs: false`.


## `with_dialog/3` function
Wraps an inner function.
Similar to [within/3](https://hexdocs.pm/phoenix_test/PhoenixTest.html#within/3).
Somewhat similar to official playwright clients for [Node.js](https://playwright.dev/docs/dialogs#alert-confirm-prompt-dialogs), Python etc. in that dialog handling must be set up before performing the action that triggers the dialog.

```ex
|> with_dialog(
  fn %{message: "Are you sure?"} -> :accept end,
  fn conn ->
    conn
    |> click_button("Delete")
    |> assert_has(".flash", text: "Deleted")
  end
end)
```

Unfortunately, a "linear" API is difficult to support because `click_link` blocks (is synchronous):

```ex
# ❌ Can't do this
|> click_link("Delete")
|> accept_dialog("Are you sure?")
```

Playwright waits to see if the `click` is successful. As long as the dialog is open, playwright waits and `click` doesn't succeed.
The internal Playwright websocket protocol is actually async. `PhoenixTest.Playwright` functions are blocking by choice.
We could provide non-blocking variants (or options). But we would then miss out on some errors playwright could catch, e.g. that the link is not actionable.