### PR TITLE
minifix: Remove empty brackets

### DIFF
--- a/lib/phoenix_test/playwright/connection.ex
+++ b/lib/phoenix_test/playwright/connection.ex
@@ -206,6 +206,10 @@ defmodule PhoenixTest.Playwright.Connection do
 
   defp log_console(state, _), do: state
 
+  def add_location(text, %{params: %{location: %{url: ""}}} = _message) do
+    "#{text}"
+  end
+
   def add_location(text, %{params: %{location: %{url: url, line_number: 0}}} = _message) do
     "#{text} (#{url})"
   end

--- a/test/phoenix_test/playwright/connection_test.exs
+++ b/test/phoenix_test/playwright/connection_test.exs
@@ -112,5 +112,19 @@ defmodule PhoenixTest.Playwright.ConnectionTest do
     }
 
     assert "Hi (http://localhost:4002/assets/app.js)" == Connection.add_location("Hi", message)
+
+    # shortend, line number 0
+    message = %{
+      params: %{
+        type: "log",
+        location: %{
+          url: ""
+        },
+        text: "hello world"
+      },
+      method: :console
+    }
+
+    assert "Hi" == Connection.add_location("Hi", message)
   end
 end

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -906,7 +906,7 @@ defmodule PhoenixTest.PlaywrightTest do
           |> tap(&PhoenixTest.Playwright.Frame.evaluate(&1.frame_id, "console.error('TESTME 42')"))
         end)
 
-      assert log =~ "TESTME 42 ()"
+      assert log =~ "TESTME 42\n"
     end
   end
 end


### PR DESCRIPTION
_"For example (note the empty () brackets for unknown location in 2nd test)"_ #41 

Just in case you don't like the empty brackets either 😄 