### PR TITLE
Allow setting the preferred JS package runner (`npx`, `bunx`)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,7 @@ config :phoenix_test,
   endpoint: PhoenixTest.Endpoint,
   otp_app: :phoenix_test_playwright,
   playwright: [
-    cli: "priv/static/assets/node_modules/playwright/cli.js",
+    assets_dir: "priv/static/assets",
     headless: System.get_env("PW_HEADLESS", "true") in ~w(t true),
     screenshot: System.get_env("PW_SCREENSHOT", "false") in ~w(t true),
     trace: System.get_env("PW_TRACE", "false") in ~w(t true),

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -63,7 +63,6 @@ defmodule PhoenixTest.Playwright.Case do
     alias PhoenixTest.Playwright.Browser
     alias PhoenixTest.Playwright.BrowserContext
     alias PhoenixTest.Playwright.Page
-    alias PhoenixTest.Playwright.Port
 
     @includes_ecto Code.ensure_loaded?(Sandbox) &&
                      Code.ensure_loaded?(Phoenix.Ecto.SQL.Sandbox)
@@ -113,8 +112,7 @@ defmodule PhoenixTest.Playwright.Case do
         BrowserContext.stop_tracing(browser_context_id, path)
 
         if config[:trace] == :open do
-          cli_path = Path.join(File.cwd!(), Port.cli_path())
-          System.cmd(cli_path, ["show-trace", path])
+          System.cmd(Config.global(:runner), ["playwright", "show-trace", path], cd: Config.global(:assets_dir))
         end
       end)
     end

--- a/lib/phoenix_test/playwright/config.ex
+++ b/lib/phoenix_test/playwright/config.ex
@@ -12,9 +12,17 @@ schema =
       type: {:in, browsers},
       type_doc: "`#{Enum.map_join(browsers, " | ", &":#{&1}")}`"
     ],
-    cli: [
-      default: "assets/node_modules/playwright/cli.js",
-      type: :string
+    runner: [
+      default: "npx",
+      type_spec: quote(do: binary()),
+      type: {:custom, PhoenixTest.Playwright.Config, :__validate_runner__, []},
+      doc:
+        "The JS package runner to use to run the playwright CLI. Accepts either a binary executable exposed in PATH or the absolute path to it."
+    ],
+    assets_dir: [
+      default: "assets",
+      type: :string,
+      doc: "The directory where the JS assets are located."
     ],
     executable_path: [
       type: :string,
@@ -65,7 +73,7 @@ schema =
     accept_dialogs: [
       default: true,
       type: :boolean,
-      doc: "Accept browser dialogs (`alert()`, `confirm()`, `prompt()`"
+      doc: "Accept browser dialogs (`alert()`, `confirm()`, `prompt()`)"
     ]
   )
 
@@ -119,4 +127,21 @@ defmodule PhoenixTest.Playwright.Config do
 
   defp normalize(:screenshot, true), do: NimbleOptions.validate!([], @screenshot_opts_schema)
   defp normalize(_key, value), do: value
+
+  def __validate_runner__(runner) do
+    if System.find_executable(runner) do
+      {:ok, runner}
+    else
+      message = """
+      could not find runner executable at `#{runner}`.
+
+      To resolve this please
+      1. Install a JS package runner like `npx` or `bunx`
+      2. Configure the preferred runner in `config/test.exs`, e.g.: `config :phoenix_test, playwright: [runner: "npx"]`
+      3. Ensure either the runner is in your PATH or the `runner` value is a absolute path to the executable (e.g. `Path.absname("_build/bun")`)
+      """
+
+      {:error, message}
+    end
+  end
 end

--- a/lib/phoenix_test/playwright/port.ex
+++ b/lib/phoenix_test/playwright/port.ex
@@ -15,26 +15,13 @@ defmodule PhoenixTest.Playwright.Port do
     :buffer
   ]
 
-  def cli_path do
-    path = Config.global(:cli)
-
-    if !File.exists?(path) do
-      msg = """
-      Could not find playwright CLI at #{path}.
-
-      To resolve this please
-      1. Install playwright, e.g. `npm i playwright`
-      2. Configure the path correctly, e.g. in `config/test.exs`: `config :phoenix_test, playwright: [cli: "assets/node_modules/playwright/cli.js"]`
-      """
-
-      raise ArgumentError, msg
-    end
-
-    path
-  end
-
   def open do
-    port = Port.open({:spawn, "#{cli_path()} run-driver"}, [:binary])
+    port =
+      Port.open(
+        {:spawn, "#{Config.global(:runner)} playwright run-driver"},
+        [:binary, cd: Config.global(:assets_dir)]
+      )
+
     %__MODULE__{port: port, remaining: 0, buffer: ""}
   end
 


### PR DESCRIPTION
Allow the user to set the preferred JS package runner that runs the Playwright CLI. That enables the user to call the CLI in different ways like `npx playwright`, `bunx playwright`, or `/path/to/bun playwright`.

It replaces the `cli` option with `runner` and `assets_dir`.

Resolves #47