### PR TITLE
Speed up PhoenixTestPlaywright test suites by retrying more often and allowing for lowering the refute timeout

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -391,15 +391,17 @@ defmodule PhoenixTest.Playwright do
 
   @doc false
   def retry(fun, current_sleep \\ 0, max_sleep \\ timeout())
+
   def retry(fun, current_sleep, max_sleep) when current_sleep >= max_sleep do
     fun.()
   end
+
   def retry(fun, current_sleep, max_sleep) do
     fun.()
   rescue
     ExUnit.AssertionError ->
       Process.sleep(10)
-      retry(fun, current_sleep+10, max_sleep)
+      retry(fun, current_sleep + 10, max_sleep)
   end
 
   @doc false
@@ -629,11 +631,16 @@ defmodule PhoenixTest.Playwright do
     # We might want refute timeout to be much lower, to prevent constantly
     # checking for something that shouldn't exist.
     opts = Keyword.put_new(opts, :timeout, refute_timeout())
-    retry(fn ->
-      if found?(conn, selector, opts) do
-        flunk("Found element #{selector} #{inspect(opts)}")
-      end
-    end, 0, refute_timeout())
+
+    retry(
+      fn ->
+        if found?(conn, selector, opts) do
+          flunk("Found element #{selector} #{inspect(opts)}")
+        end
+      end,
+      0,
+      refute_timeout()
+    )
 
     conn
   end

--- a/lib/phoenix_test/playwright/config.ex
+++ b/lib/phoenix_test/playwright/config.ex
@@ -62,6 +62,10 @@ schema =
       default: to_timeout(second: 2),
       type: :non_neg_integer
     ],
+    refute_timeout: [
+      default: to_timeout(second: 2),
+      type: :non_neg_integer
+    ],
     slow_mo: [
       default: to_timeout(second: 0),
       type: :non_neg_integer


### PR DESCRIPTION
Asking Playwright to wait for a selector for `refute` tests up to 2s was significantly increasing the time for playwright test suites - this cut off 6s from some of my tests, resulting in a hugely faster feature test suite.

I think the default should probably be 1 millisecond and folks should be expected to wait for a different selector before they refute one, but that's backwards incompatible and I know it bites people sometimes.

This also makes `retry` try more often, because I was checking for paths and it was waiting `100ms`, which was just too long. Backoff wasn't really what I wanted - it's in one process, I wanted it to check as often as reasonable until it passed or hit the timeout.