### PR TITLE
Bump Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule PhoenixTestPlaywright.MixProject do
       app: :phoenix_test_playwright,
       version: @version,
       description: @description,
-      elixir: "~> 1.15",
+      elixir: "~> 1.18",
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),


### PR DESCRIPTION
`lib/phoenix_test/playwright/config.ex:194` uses Elixir's native `JSON` module,
[added in v1.18](https://github.com/elixir-lang/elixir/releases/tag/v1.18.0)