### PR TITLE
Fix: Allow passing custom options via browser_context_opts and browser_page_opts

### DIFF
--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -97,11 +97,11 @@ defmodule PhoenixTest.Playwright.Case do
     user_agent = checkout_ecto_repos(config, context) || "No user agent"
     base_url = Application.fetch_env!(:phoenix_test, :base_url)
     context_opts_defaults = [base_url: base_url, locale: "en", user_agent: user_agent, timeout: config[:timeout]]
-    context_opts = Keyword.validate!(config[:browser_context_opts], context_opts_defaults)
+    context_opts = Keyword.merge(context_opts_defaults, config[:browser_context_opts])
     {:ok, browser_context} = Browser.new_context(context.browser_id, context_opts)
     register_selector_engines!(browser_context.guid, config)
 
-    page_opts = Keyword.validate!(config[:browser_page_opts], timeout: config[:timeout])
+    page_opts = Keyword.merge([timeout: config[:timeout]], config[:browser_page_opts])
     {:ok, page} = BrowserContext.new_page(browser_context.guid, page_opts)
     {:ok, _} = Page.update_subscription(page.guid, event: :console, enabled: true, timeout: config[:timeout])
     {:ok, _} = Page.update_subscription(page.guid, event: :dialog, enabled: true, timeout: config[:timeout])


### PR DESCRIPTION
# Fix: Allow passing custom options via `browser_context_opts` and `browser_page_opts`

## Problem

The `browser_context_opts` and `browser_page_opts` configuration options are documented as passing additional arguments to Playwright's `Browser.newContext` and `BrowserContext.newPage`, but in practice they reject any keys not in the hardcoded defaults.

For example, trying to set a custom viewport:

```elixir
config :phoenix_test,
  playwright: [
    browser_context_opts: [viewport: %{width: 1920, height: 1080}]
  ]
```

Results in:

```
** (ArgumentError) unknown keys [:viewport] in [...], the allowed keys are: [:base_url, :locale, :user_agent, :timeout]
```

This happens because `Keyword.validate!/2` is used, which rejects any keys not present in the defaults.

## Solution

Replace `Keyword.validate!/2` with `Keyword.merge/2` to:
1. Apply the library's defaults (`base_url`, `locale`, `user_agent`, `timeout`)
2. Allow user-provided options to override defaults
3. Pass through additional Playwright options like `viewport`, `http_credentials`, `color_scheme`, etc.

## Changes

```diff
-    context_opts = Keyword.validate!(config[:browser_context_opts], context_opts_defaults)
+    context_opts = Keyword.merge(context_opts_defaults, config[:browser_context_opts])

-    page_opts = Keyword.validate!(config[:browser_page_opts], timeout: config[:timeout])
+    page_opts = Keyword.merge([timeout: config[:timeout]], config[:browser_page_opts])
```

## Use Cases Enabled

This fix allows users to pass any valid Playwright context/page options, including:
- `viewport` - Set custom viewport dimensions
- `http_credentials` - HTTP authentication
- `color_scheme` - Emulate light/dark mode
- `device_scale_factor` - Emulate device pixel ratio
- `is_mobile` - Emulate mobile device
- `java_script_enabled` - Disable JavaScript
- And all other options supported by [Browser.newContext](https://playwright.dev/docs/api/class-browser#browser-new-context)