### PR TITLE
Support timeout opt in `Playwright.visit`

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -323,7 +323,12 @@ defmodule PhoenixTest.Playwright do
   end
 
   @doc false
-  def visit(conn, path, opts \\ []) do
+  def visit(conn, path), do: visit(conn, path, [])
+
+  @doc """
+  Like `PhoenixTest.visit/2`, but with a custom `timeout`.
+  """
+  def visit(conn, path, opts) do
     opts = Keyword.validate!(opts, timeout: timeout())
     tap(conn, &({:ok, _} = Frame.goto(&1.frame_id, Keyword.put(opts, :url, path))))
   end

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -47,6 +47,7 @@ defmodule PhoenixTest.Playwright.Case do
           screenshot: 3,
           type: 3,
           type: 4,
+          visit: 3,
           with_dialog: 3
         ]
 


### PR DESCRIPTION
This allows a custom timeout for the `visit` action in particular, with the global timeout as the default.