### PR TITLE
Fix failure to open trace when :trace_dir is an absolute path

### DIFF
--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -148,7 +148,7 @@ defmodule PhoenixTest.Playwright.Case do
 
   defp maybe_open_trace(:open, path) do
     # Spawn to avoid blocking the test exit
-    spawn(fn -> System.cmd(Playwright.Config.executable(), ["show-trace", Path.join(File.cwd!(), path)]) end)
+    spawn(fn -> System.cmd(Playwright.Config.executable(), ["show-trace", Path.absname(path)]) end)
     :ok
   end
 


### PR DESCRIPTION
This fixes an issue we ran into at work. We had set our `:trace_dir` configuration to `"/tmp/traces"`, and when we tried to run with `trace: :open`, we would get an error like the following printed to the console:

> Error: Trace file /Users/tyler/jump/api/tmp/traces/JumpWeb.Components.Core.PickerBrowserTest.test_can_search_within_a_picker_1769012948_9.zip does not exist!

This makes it so that both relative and absolute trace paths are supported on our project.

(I wasn't really sure how to write an automated test for this... certainly open to suggestions!)