### PR TITLE
Fix submit after selecting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## Unreleased
+### Fixed
+- `submit/1` no longer relies on pressing Enter, so forms submit consistently when the last interacted element is a select.
+
 ## [0.14.0] 2026-05-05
 ### Added
 - Support phoenix_test [v0.11.1](https://hexdocs.pm/phoenix_test/changelog.html#0-11-1). Commit [f60d668]

--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -843,7 +843,38 @@ defmodule PhoenixTest.Playwright do
 
   @doc false
   def submit(conn) do
-    Frame.press(conn.frame_id, selector: conn.last_input_selector, key: "Enter", timeout: timeout())
+    conn.frame_id
+    |> Frame.focus(selector: conn.last_input_selector, timeout: timeout())
+    |> handle_response(conn.last_input_selector)
+
+    case Frame.evaluate(conn.frame_id,
+           expression: """
+           () => {
+             const element = document.activeElement;
+             const form = element && element.form;
+
+             if (!form) {
+               throw new Error("Last interacted element is not associated with a form");
+             }
+
+             const submitter = form.querySelector(
+               'button:not([type]):not(:disabled), button[type="submit"]:not(:disabled), input[type="submit"]:not(:disabled), input[type="image"]:not(:disabled)'
+             );
+
+             form.requestSubmit(submitter || undefined);
+           }
+           """,
+           is_function: true,
+           timeout: timeout()
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, error} ->
+        raise ExUnit.AssertionError,
+          message: "Could not submit form for selector \"#{conn.last_input_selector}\":\n#{more_info(error)}"
+    end
+
     conn
   end
 

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -199,6 +199,16 @@ defmodule PhoenixTest.PlaywrightTest do
     end
   end
 
+  describe "submit/1" do
+    test "submits the form when the last interacted input is a select", %{conn: conn} do
+      conn
+      |> visit("/pw/live")
+      |> select("Select input", option: "Two")
+      |> submit()
+      |> assert_has("#submitted-form-data", text: "select: two")
+    end
+  end
+
   describe "drag/3" do
     test "triggers a javascript event handler", %{conn: conn} do
       conn

--- a/test/support/playwright/live.ex
+++ b/test/support/playwright/live.ex
@@ -12,6 +12,14 @@ defmodule PhoenixTest.Playwright.Live do
       <input id="text-input" name="text" />
     </.form>
 
+    <.form for={%{}} phx-submit="save">
+      <label for="select-input">Select input</label>
+      <select id="select-input" name="select" onkeydown="if (event.key === 'Enter') event.preventDefault()">
+        <option value="one">One</option>
+        <option value="two">Two</option>
+      </select>
+    </.form>
+
     <dl id="changed-form-data">
       <%= for {key, value} <- @changed_form_data do %>
         <dt>{key}:</dt> <dd>{value}</dd>
@@ -19,7 +27,7 @@ defmodule PhoenixTest.Playwright.Live do
     </dl>
 
     <dl id="submitted-form-data">
-      <%= for {key, value} <- @changed_form_data do %>
+      <%= for {key, value} <- @submitted_form_data do %>
         <dt>{key}:</dt> <dd>{value}</dd>
       <% end %>
     </dl>


### PR DESCRIPTION
`submit/1` form via Javascript instead of `Enter` key press.

## Why make these changes?
On Linux, `select...() |> submit()` failed.
Because `Enter` key on select opened the select, instead of submitting the form.

## What changed?
- make submit/1 submit the owning form directly instead of pressing Enter
