### PR TITLE
feat (Frame): Accept all supported options to `goto`

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -155,7 +155,25 @@ defmodule PhoenixTest.Playwright do
   @doc false
   def visit(conn, path), do: visit(conn, path, [])
 
-  @visit_opts_schema [timeout: @timeout_opt]
+  @visit_opts_schema [
+    timeout: @timeout_opt,
+    referer: [
+      type: :string,
+      doc:
+        "Referer header value. If provided, takes preference over the referer header set via the `extra_http_headers` option to `PlaywrightEx.Browser.new_context/2`."
+    ],
+    wait_until: [
+      type: {:in, ["load", "domcontentloaded", "networkidle", "commit"]},
+      default: "load",
+      doc: """
+      When to consider the operation succeeded. One of:
+      - `"load"` (default) — fires when the `load` event is fired.
+      - `"domcontentloaded"` — fires when the `DOMContentLoaded` event is fired.
+      - `"networkidle"` — **discouraged** — fires when there are no network connections for at least 500 ms. Rely on web assertions instead for testing readiness.
+      - `"commit"` — fires when the network response is received and the document has started loading.
+      """
+    ]
+  ]
 
   @doc """
   Like `PhoenixTest.visit/2`, but with a custom `timeout`.


### PR DESCRIPTION
The corresponding change to be able to use [#49 from playwright_ex](https://github.com/ftes/playwright_ex/pull/49). The description from that PR:

> This expands the list of selected options for `PlaywrightEx.Frame.goto/2` to match those of the JavaScript API ([docs](https://playwright.dev/docs/api/class-page#page-goto)).
>
> I found that in CI, I was often hitting 30 second timeouts waiting for the `load` event—even though in the trace, I could clearly see the page had (at least conceptually!) loaded. When switching to `waitUntil: 'commit'` (rather than the default `waitUntil: 'load'`), not only did the flakiness of that initial page load get fixed, but the tests also got _much_ faster: from an average of >5 seconds per test down to under 1.5 seconds/test.
>
> (The `Referer` stuff isn't strictly necessary for my own work, but I figured while I was in here, I might as well make `goto` accept everything the JavaScript version does.)

It doesn't feel _great_ having the docs copied and pasted between the two projects, but it seemed cleaner than, say, exposing a function from PlaywrightEx that would provide the options at compile-time.