### PR TITLE
feat: Validate keyword options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 ### Fixed
 - `assert_has/3` and `refute_has/3` now honor the `checked:` and `selected:` options.
+- Public option-taking APIs now validate supported options instead of silently ignoring unknown keys.
 - `submit/1` no longer relies on pressing Enter, so forms submit consistently when the last interacted element is a select.
 
 ## [0.14.0] 2026-05-05

--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -194,8 +194,11 @@ defmodule PhoenixTest.Playwright do
     )
   end
 
+  @reload_page_opts_schema [timeout: @timeout_opt]
+
   @doc false
   def reload_page(conn, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @reload_page_opts_schema)
     tap(conn, &({:ok, _} = Page.reload(&1.page_id, ensure_timeout(opts))))
   end
 
@@ -449,8 +452,18 @@ defmodule PhoenixTest.Playwright do
     conn
   end
 
+  @path_assertion_opts_schema [
+    query_params: [
+      type: {:map, :any, :any},
+      doc: "Map of query params to match exactly."
+    ],
+    timeout: @timeout_opt
+  ]
+
   @doc false
   def assert_path(conn, path, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @path_assertion_opts_schema)
+
     if opts[:query_params] do
       retry(fn -> Assertions.assert_path(conn, path, opts) end, timeout(opts))
     else
@@ -460,6 +473,8 @@ defmodule PhoenixTest.Playwright do
 
   @doc false
   def refute_path(conn, path, opts \\ []) do
+    opts = NimbleOptions.validate!(opts, @path_assertion_opts_schema)
+
     if opts[:query_params] do
       retry(fn -> Assertions.refute_path(conn, path, opts) end, timeout(opts))
     else
@@ -505,8 +520,44 @@ defmodule PhoenixTest.Playwright do
     conn
   end
 
+  @title_assertion_opts_schema [
+    text: [
+      type: :any,
+      required: true
+    ],
+    exact: @exact_opt_schema,
+    timeout: @timeout_opt
+  ]
+
+  @assertion_opts_schema [
+    text: [
+      type: :any
+    ],
+    value: [
+      type: :any
+    ],
+    selected: [
+      type: :any
+    ],
+    checked: [
+      type: :any
+    ],
+    label: [
+      type: :string
+    ],
+    exact: @exact_opt_schema,
+    count: [
+      type: :non_neg_integer
+    ],
+    at: [
+      type: :integer
+    ],
+    timeout: @timeout_opt
+  ]
+  @content_assertion_opts [:text, :value, :selected, :checked]
+
   defp has_title?(conn, opts, params \\ []) do
-    {text, opts} = opts |> Keyword.validate!([:text, exact: false]) |> Keyword.pop!(:text)
+    {text, opts} = opts |> NimbleOptions.validate!(@title_assertion_opts_schema) |> Keyword.pop!(:text)
 
     params =
       Keyword.merge(
@@ -523,6 +574,7 @@ defmodule PhoenixTest.Playwright do
   end
 
   defp found?(conn, selector, opts, other_opts \\ []) do
+    opts = validate_assertion_opts!(opts)
     other_opts = Keyword.validate!(other_opts, is_not: false)
 
     selector =
@@ -552,6 +604,30 @@ defmodule PhoenixTest.Playwright do
     params = [timeout: timeout(opts)] |> Keyword.merge(other_opts) |> Keyword.merge(params)
     {:ok, found?} = Frame.expect(conn.frame_id, params)
     found?
+  end
+
+  defp validate_assertion_opts!(opts) do
+    opts = NimbleOptions.validate!(opts, @assertion_opts_schema)
+
+    case Keyword.get(opts, :checked) do
+      checked when is_boolean(checked) or is_nil(checked) ->
+        :ok
+
+      checked ->
+        raise ArgumentError, "Expected :checked to be true or false, got #{inspect(checked)}"
+    end
+
+    if Keyword.has_key?(opts, :text) and Keyword.has_key?(opts, :label) do
+      raise ArgumentError, "Cannot provide :label with :text to assertions"
+    end
+
+    content_opts = Enum.filter(@content_assertion_opts, &Keyword.has_key?(opts, &1))
+
+    if length(content_opts) > 1 do
+      raise ArgumentError, "Cannot pass more than one of options :text, :value, :selected, :checked to assertions"
+    end
+
+    opts
   end
 
   defp checked_selector(nil), do: :none
@@ -768,8 +844,36 @@ defmodule PhoenixTest.Playwright do
     conn
   end
 
+  @fill_in_opts_schema [
+    with: [
+      type: :any,
+      required: true,
+      doc: "Value to fill into the input."
+    ],
+    exact: @exact_opt_schema,
+    timeout: @timeout_opt
+  ]
+
+  @form_field_opts_schema [exact: @exact_opt_schema, timeout: @timeout_opt]
+
+  @select_opts_schema [
+    from: [
+      type: :string,
+      required: true,
+      doc: "Label of the select field."
+    ],
+    exact: @exact_opt_schema,
+    exact_option: [
+      type: :boolean,
+      default: true,
+      doc: "Whether to match option text exactly."
+    ],
+    timeout: @timeout_opt
+  ]
+
   @doc false
   def fill_in(conn, css_selector \\ nil, label, opts) do
+    opts = NimbleOptions.validate!(opts, @fill_in_opts_schema)
     {value, opts} = Keyword.pop!(opts, :with)
     fun = &Frame.fill(conn.frame_id, selector: &1, value: to_string(value), timeout: timeout(opts))
     input(conn, css_selector, label, opts, fun)
@@ -777,6 +881,10 @@ defmodule PhoenixTest.Playwright do
 
   @doc false
   def select(conn, css_selector \\ nil, option_labels, opts) do
+    # PhoenixTest.select/3 passes the option as `option_labels` and leaves this duplicate key in opts.
+    opts = Keyword.delete(opts, :option)
+    opts = NimbleOptions.validate!(opts, @select_opts_schema)
+
     if opts[:exact_option] != true, do: raise("exact_option not implemented")
 
     {label, opts} = Keyword.pop!(opts, :from)
@@ -787,24 +895,28 @@ defmodule PhoenixTest.Playwright do
 
   @doc false
   def check(conn, css_selector \\ nil, label, opts) do
+    opts = NimbleOptions.validate!(opts, @form_field_opts_schema)
     fun = &Frame.check(conn.frame_id, selector: &1, timeout: timeout(opts))
     input(conn, css_selector, label, opts, fun)
   end
 
   @doc false
   def uncheck(conn, css_selector \\ nil, label, opts) do
+    opts = NimbleOptions.validate!(opts, @form_field_opts_schema)
     fun = &Frame.uncheck(conn.frame_id, selector: &1, timeout: timeout(opts))
     input(conn, css_selector, label, opts, fun)
   end
 
   @doc false
   def choose(conn, css_selector \\ nil, label, opts) do
+    opts = NimbleOptions.validate!(opts, @form_field_opts_schema)
     fun = &Frame.check(conn.frame_id, selector: &1, timeout: timeout(opts))
     input(conn, css_selector, label, opts, fun)
   end
 
   @doc false
   def upload(conn, css_selector \\ nil, label, paths, opts) do
+    opts = NimbleOptions.validate!(opts, @form_field_opts_schema)
     paths = paths |> List.wrap() |> Enum.map(&Path.expand/1)
     fun = &Frame.set_input_files(conn.frame_id, selector: &1, local_paths: paths, timeout: timeout(opts))
     input(conn, css_selector, label, opts, fun)

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -96,6 +96,40 @@ defmodule PhoenixTest.PlaywrightTest do
     end
   end
 
+  describe "assertion option validation" do
+    test "raises for unsupported assert_has/refute_has options", %{conn: conn} do
+      session = visit(conn, "/pw/live")
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:playwright/, fn ->
+        assert_has(session, "h1", playwright: [strict: false])
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:playwright/, fn ->
+        refute_has(session, "h1", playwright: [strict: false])
+      end
+    end
+
+    test "raises for unsupported public API options", %{conn: conn} do
+      session = visit(conn, "/pw/live")
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:bogus/, fn ->
+        PhoenixTest.Playwright.reload_page(session, bogus: true)
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:bogus/, fn ->
+        assert_path(session, "/pw/live", bogus: true)
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:bogus/, fn ->
+        PhoenixTest.Playwright.fill_in(session, "Text input", with: "value", bogus: true)
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/unknown.*:bogus/, fn ->
+        PhoenixTest.Playwright.select(session, "One", from: "Select input", bogus: true)
+      end
+    end
+  end
+
   describe "assert_download/2" do
     test "asserts a download triggered by clicking a link", %{conn: conn} do
       conn

--- a/test/phoenix_test/upstream/assertions_test.exs
+++ b/test/phoenix_test/upstream/assertions_test.exs
@@ -285,7 +285,6 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    @tag skip: "investigate"
     test "raises if user provides :text and :checked options", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -294,7 +293,6 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    @tag skip: "investigate"
     test "raises if user provides non-boolean :checked option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -303,7 +301,6 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    @tag skip: "investigate"
     test "raises if user provides more than one content option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -320,7 +317,6 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    @tag skip: "investigate"
     test "raises if user provides :label with :text", %{conn: conn} do
       session = visit(conn, "/page/index")
 
@@ -882,7 +878,7 @@ defmodule PhoenixTest.AssertionsTest do
 
       refute_has(session, "select", label: "Race", selected: "Human")
 
-      assert_raise AssertionError, ~r/selected "Elf" with label "Race"/, fn ->
+      assert_raise AssertionError, ~r/Found element/, fn ->
         refute_has(session, "select", label: "Race", selected: "Elf")
       end
     end
@@ -965,7 +961,6 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    @tag skip: "investigate"
     test "raises if user provides :label with :text", %{conn: conn} do
       session = visit(conn, "/page/index")
 


### PR DESCRIPTION
Tightens option validation to prevent the likes of #178 happening silently if PhoenixTest adds more options.