### PR TITLE
chore: Upgrade to new error format (after ftes/playwright_ex#58 drops support for 1.60)

### DIFF
--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -424,11 +424,11 @@ defmodule PhoenixTest.Playwright do
         write_file!(snapshot_path, actual_b64)
         conn
 
-      {:error, %{diff: diff, custom_error_message: msg}} when is_binary(diff) ->
+      {:error, {_, %{diff: diff, custom_error_message: msg}}} when is_binary(diff) ->
         write_file!(Path.join([snapshot_dir, "__diff__", name]), diff)
         flunk("Screenshot mismatch for #{name}: #{msg}")
 
-      {:error, %{custom_error_message: msg}} ->
+      {:error, {_, %{custom_error_message: msg}}} ->
         flunk(msg)
     end
   end

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -73,7 +73,7 @@ defmodule PhoenixTest.PlaywrightTest do
     @tag :tmp_dir
     test "raises on invalid clip option", %{conn: conn, tmp_dir: tmp_dir} do
       assert_raise ExUnit.AssertionError,
-                   ~r"Expected options.clip.width not to be 0.",
+                   ~r"Expected options.clip.width to be greater than 0.",
                    fn ->
                      assert_screenshot(conn, "clip.png",
                        snapshot_dir: tmp_dir,


### PR DESCRIPTION
Based on [Wigny/phoenix_test_playwright#add-assert-screenshot](https://github.com/Wigny/phoenix_test_playwright/tree/add-assert-screenshot)