### PR TITLE
Fix browser teardown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 - Fix for `assert_has(selector, text: ...)` failing when a hidden text match precedes a visible one in DOM order (#194)
+- Wait for browser contexts and browsers to close during graceful ExUnit and application shutdown (#205)
 
 ## [0.15.0] 2026-06-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ P.S. Looking for a standalone Playwright client? See [PlaywrightEx](https://gith
     Application.put_env(:phoenix_test, :base_url, YourAppWeb.Endpoint.url())
     ```
 
+    Graceful ExUnit and application shutdown waits for browser contexts and
+    browsers to close. Abrupt termination such as `SIGKILL` cannot run this
+    cleanup.
+
 5. Use in test
 
     ```elixir

--- a/lib/phoenix_test/playwright/case.ex
+++ b/lib/phoenix_test/playwright/case.ex
@@ -11,6 +11,9 @@ defmodule PhoenixTest.Playwright.Case do
   - using config opt `browser_context_opts`, which are passed to `PlaywrightEx.Browser.new_context/2`
   - using config opt `browser_page_opts`, which are passed to `PlaywrightEx.BrowserContext.new_page/2`
   - implementing your own `Case` (the setup functions in this module are public for your convenience)
+
+  Browser contexts and non-pooled browsers are closed before their ExUnit
+  teardown callbacks return.
   """
 
   use ExUnit.CaseTemplate
@@ -95,7 +98,8 @@ defmodule PhoenixTest.Playwright.Case do
     timeout = Keyword.fetch!(config, :browser_launch_timeout)
     browser = PhoenixTest.Playwright.Browser.launch_browser!(config)
 
-    on_exit(fn -> spawn(fn -> Browser.close(browser.guid, timeout: timeout) end) end)
+    on_exit(fn -> Browser.close(browser.guid, timeout: timeout) end)
+
     browser.guid
   end
 
@@ -111,7 +115,8 @@ defmodule PhoenixTest.Playwright.Case do
     {:ok, page} = BrowserContext.new_page(browser_context.guid, page_opts)
     {:ok, _} = Page.update_subscription(page.guid, event: :console, enabled: true, timeout: config[:timeout])
     {:ok, _} = Page.update_subscription(page.guid, event: :dialog, enabled: true, timeout: config[:timeout])
-    on_exit(fn -> spawn(fn -> BrowserContext.close(browser_context.guid, timeout: config[:timeout]) end) end)
+
+    on_exit(fn -> BrowserContext.close(browser_context.guid, timeout: config[:timeout]) end)
 
     if config[:trace], do: trace(browser_context.tracing.guid, config, context)
 

--- a/lib/phoenix_test/playwright/internal/browser_pool.ex
+++ b/lib/phoenix_test/playwright/internal/browser_pool.ex
@@ -6,6 +6,7 @@ defmodule PhoenixTest.Playwright.BrowserPool do
 
   Pools are defined up front.
   Browsers are launched lazily.
+  All launched browsers are closed before the pool terminates.
   """
 
   use GenServer
@@ -80,7 +81,7 @@ defmodule PhoenixTest.Playwright.BrowserPool do
     timeout = Config.global(:timeout)
 
     for browser_id <- state.available ++ Map.keys(state.in_use) do
-      spawn(fn -> PlaywrightEx.Browser.close(browser_id, timeout: timeout) end)
+      PlaywrightEx.Browser.close(browser_id, timeout: timeout)
     end
   end
 


### PR DESCRIPTION
## Summary

- wait for browser-context and non-pooled-browser close operations during ExUnit teardown
- close all pooled browsers synchronously before the pool terminates
- document graceful-shutdown behavior and the abrupt-termination boundary

## Root cause

Teardown started browser close operations in untracked processes and returned immediately. ExUnit or the application supervisor could therefore finish while those processes were still using the Playwright connection, leaving local browser processes behind after otherwise graceful shutdowns.

## Impact

Graceful test-suite and application shutdown now waits for browser resources to close, preventing avoidable accumulation of orphaned headless browsers across local runs. Truly abrupt termination such as `SIGKILL` remains outside this cleanup path.

Closes #205