### PR TITLE
Close pooled browsers concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 - Fix for `assert_has(selector, text: ...)` failing when a hidden text match precedes a visible one in DOM order (#194)
-- Wait for browser contexts and browsers to close during graceful ExUnit and application shutdown (#205)
+- Wait for browser contexts and browsers to close during graceful ExUnit and application shutdown,
+  closing pooled browsers concurrently (#205)
 
 ## [0.15.0] 2026-06-19
 ### Added

--- a/lib/phoenix_test/playwright/internal/browser_pool.ex
+++ b/lib/phoenix_test/playwright/internal/browser_pool.ex
@@ -80,9 +80,12 @@ defmodule PhoenixTest.Playwright.BrowserPool do
   def terminate(_reason, state) do
     timeout = Config.global(:timeout)
 
-    for browser_id <- state.available ++ Map.keys(state.in_use) do
-      PlaywrightEx.Browser.close(browser_id, timeout: timeout)
-    end
+    tasks =
+      for browser_id <- state.available ++ Map.keys(state.in_use) do
+        Task.async(fn -> PlaywrightEx.Browser.close(browser_id, timeout: timeout) end)
+      end
+
+    Task.await_many(tasks, :infinity)
   end
 
   @doc false


### PR DESCRIPTION
## Summary

- start pooled browser closes concurrently during `BrowserPool.terminate/2`
- await every close task before termination returns
- document the concurrent shutdown behavior in the changelog

This follows up on #206 and addresses [the shutdown-budget review comment](https://github.com/ftes/phoenix_test_playwright/pull/206#discussion_r3645305331). Running the closes concurrently prevents multiple per-browser timeouts from accumulating serially against the pool worker's shutdown budget. `Task.await_many/2` uses `:infinity` because each `Browser.close/2` call already enforces the configured browser timeout.
