### PR TITLE
fix: click selector elements containing visible text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Fixed
 - Fix for `assert_has(selector, text: ...)` failing when a hidden text match precedes a visible one in DOM order (#194)
+- Make `click(selector, text)` click the selector element containing visible text without hidden duplicate text descendants causing a strictness failure (#220)
 - Wait for browser contexts and browsers to close during graceful ExUnit and application shutdown,
   closing pooled browsers concurrently (#205)
 

--- a/lib/phoenix_test/playwright.ex
+++ b/lib/phoenix_test/playwright.ex
@@ -904,8 +904,11 @@ defmodule PhoenixTest.Playwright do
   end
 
   @doc """
-  Click an element that is not a link or button.
+  Click the element matching `selector` that contains visible `text`.
   Otherwise, use `click_link/4` and `click_button/4`.
+
+  The element matching `selector` remains the click target when `text` is nested
+  inside it.
 
   ## Options
   #{NimbleOptions.docs(@exact_opts_schema)}
@@ -924,7 +927,7 @@ defmodule PhoenixTest.Playwright do
       conn
       |> maybe_within()
       |> Selector.concat(selector)
-      |> Selector.concat(Selector.text(text, opts))
+      |> Selector.has(Selector.concat(Selector.text(text, opts), "visible=true"))
 
     conn.frame_id
     |> Frame.click(selector: selector, timeout: timeout(opts))

--- a/test/phoenix_test/playwright_test.exs
+++ b/test/phoenix_test/playwright_test.exs
@@ -232,6 +232,50 @@ defmodule PhoenixTest.PlaywrightTest do
     end
   end
 
+  describe "click/3" do
+    test "clicks the selector when it contains duplicate visible and hidden text", %{conn: conn} do
+      conn
+      |> visit("/pw/live")
+      |> evaluate("""
+      document.body.insertAdjacentHTML("beforeend", `
+        <table id="hidden-duplicate-click-repro">
+          <tr>
+            <td onclick="document.getElementById('hidden-duplicate-click-status').textContent = 'clicked'">
+              <div>Changed by production</div>
+              <div hidden><div>Changed by production</div></div>
+            </td>
+          </tr>
+        </table>
+        <div id="hidden-duplicate-click-status">pending</div>
+      `)
+      """)
+      |> click("#hidden-duplicate-click-repro td", "Changed by production")
+      |> assert_has("#hidden-duplicate-click-status", text: "clicked")
+      |> evaluate("document.getElementById('hidden-duplicate-click-status').textContent = 'pending'")
+      |> click("#hidden-duplicate-click-repro td", "Changed by production", exact: true)
+      |> assert_has("#hidden-duplicate-click-status", text: "clicked")
+    end
+
+    test "does not click the selector when matching text is hidden", %{conn: conn} do
+      session =
+        conn
+        |> visit("/pw/live")
+        |> evaluate("""
+        document.body.insertAdjacentHTML("beforeend", `
+          <button id="hidden-only-click-repro" onclick="this.dataset.clicked = 'true'">
+            <span hidden>Delete</span>
+          </button>
+        `)
+        """)
+
+      assert_raise ArgumentError, ~r/Could not find element/, fn ->
+        click(session, "#hidden-only-click-repro", "Delete", timeout: 100)
+      end
+
+      refute_has(session, "#hidden-only-click-repro[data-clicked=true]")
+    end
+  end
+
   describe "assert_download/2" do
     test "asserts a download triggered by clicking a link", %{conn: conn} do
       conn


### PR DESCRIPTION
Make `click(selector, text)` click the selector element without hidden duplicate text descendants causing a strictness failure. Fixes #220